### PR TITLE
Add a description to a task via {}

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -49,6 +49,7 @@ pub async fn create_new_task(
     instance_url: &str,
     api_key: &str,
     task_title: &str,
+    description: Option<&str>,
     priority: Option<u8>,
 ) -> Result<(), Box<dyn Error>> {
     let client = Client::new();
@@ -57,6 +58,10 @@ pub async fn create_new_task(
     let mut task_data = json!({
         "title": task_title
     });
+
+    if let Some(desc) = description {
+        task_data["description"] = json!(desc);
+    }
 
     if let Some(priority_value) = priority {
         task_data["priority"] = json!(priority_value);

--- a/src/app.rs
+++ b/src/app.rs
@@ -151,14 +151,13 @@ impl App {
                 match key.code {
                     KeyCode::Enter => {
                         if !self.new_task_title.trim().is_empty() {
-                            // Use the parser to extract the task title, priority, and label titles
                             let parsed_task = parse_task_input(&self.new_task_title);
 
-                            // Create the new task with the parsed title, priority, and labels
                             if let Err(err) = create_new_task(
                                 instance_url,
                                 api_key,
                                 &parsed_task.title,
+                                parsed_task.description.as_deref(),
                                 parsed_task.priority,
                             )
                             .await


### PR DESCRIPTION
Enables descriptions to be added to new tasks via {}. For example, the user could type `this is my task {I can now add a description}` and "I can now add a description" would be used as the description for that task.